### PR TITLE
cosmetics in Eventview

### DIFF
--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -1073,7 +1073,7 @@
     </widget>
     <widget name="waitingtext" position="530,110" size="690,510" font="Regular;22" halign="center" valign="center" zPosition="4" />
     <widget name="chosenletter" position="530,110" size="690,510" foregroundColor="yellow" font="Regular;75" halign="center" valign="center" transparent="1" zPosition="4" />
-    <widget name="list" position="530,110" size="690,510" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" itemHeights="75,53,30" fontSizesOriginal="24,20,18" fontSizesCompact="24,18" fontSizesMinimal="24,20" />
+    <widget name="list" position="530,112" size="690,510" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" itemHeights="75,53,30" fontSizesOriginal="24,20,18" fontSizesCompact="24,18" fontSizesMinimal="24,20" />
     <widget source="Service" render="Label" position="85,394" size="425,48" foregroundColor="secondFG" font="Regular;20" transparent="1">
       <convert type="MovieInfo">ShortDescription</convert>
     </widget>
@@ -1095,7 +1095,8 @@
     <widget source="Service" render="Label" position="255,366" size="245,25" zPosition="1" foregroundColor="grey" font="Regular;20" halign="right">
       <convert type="MovieInfo">RecordServiceName</convert>
     </widget>
-    <widget name="movie_off" pixmaps="skin_default/icons/ask.png,skin_default/icons/movielist.png,skin_default/icons/quit.png,skin_default/icons/pause.png,skin_default/icons/playlist.png,skin_default/icons/playlistquit.png,skin_default/icons/loop.png" position="900,60" zPosition="10" size="45,24" transparent="1" alphatest="on"/>
+    <widget name="movie_sort" pixmaps="skin_default/icons/az.png,skin_default/icons/newtop.png,skin_default/icons/shuffle.png,skin_default/icons/za.png,skin_default/icons/oldtop.png" position="555,91" zPosition="1" size="35,20" transparent="1" alphatest="on"/>
+    <widget name="movie_off" pixmaps="skin_default/icons/ask.png,skin_default/icons/movielist.png,skin_default/icons/quit.png,skin_default/icons/pause.png,skin_default/icons/playlist.png,skin_default/icons/playlistquit.png,skin_default/icons/loop.png" position="592,91" zPosition="1" size="35,20" transparent="1" alphatest="on"/>
     <widget name="DescriptionBorder" position="0,0" size="0,0" />
   </screen>
 


### PR DESCRIPTION
change duration y-size to 65 was not well. There is atached "min". Remaining text on same line is right alignment => never will be in conflict. 
Changed for all 5 row same distance - 40pix. 
