### PR TITLE
full description in second infobar

### DIFF
--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -576,7 +576,7 @@
           <convert type="EventName">SmallRating</convert>
     </widget>
     <widget source="session.Event_Now" render="Label" position="60,200" size="570,345" font="Regular; 20" zPosition="1" transparent="1">
-          <convert type="EventName">ExtendedDescription</convert>
+          <convert type="EventName">FullDescription</convert>
     </widget>
     <widget source="session.Event_Next" render="Label" position="650,140" size="570,26" backgroundColor="secondBG" transparent="1" zPosition="1" foregroundColor="secondFG" noWrap="1" font="Regular;22" halign="left">
           <convert type="EventName">NameNext</convert>
@@ -588,7 +588,7 @@
           <convert type="EventName">SmallRating</convert>
     </widget>
     <widget source="session.Event_Next" render="Label" position="650,200" size="570,345" font="Regular; 20" zPosition="1" transparent="1">
-          <convert type="EventName">ExtendedDescription</convert>
+          <convert type="EventName">FullDescription</convert>
     </widget>
     <panel name="InfoBarTemplate"/>
   </screen>


### PR DESCRIPTION
I think, in second infobar is better full description and not extended description. 

I dont know, if it is in enigma2 - if extended descr. is not broadcasted, then use short description. 
