### PR TITLE
Satfinder and service searching changes

### DIFF
--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -90,27 +90,29 @@
   <!-- Templates -->
 
   <screen name="PlayerTemplate">
-    <widget source="session.CurrentService" render="Label" position="224,4" size="832,52" backgroundColor="transparent" zPosition="1" foregroundColor="foreground" borderWidth="2" font="Regular;24" borderColor="black" valign="center" halign="center">
+    <ePixmap alphatest="off" pixmap="PLi-HD/infobar/hd.png" position="0,0" size="1280,220" zPosition="-1" />
+
+    <widget source="session.CurrentService" render="Label" position="224,4" size="832,52" backgroundColor="black" transparent="1" zPosition="1" foregroundColor="foreground" borderWidth="2" font="Regular;24" borderColor="black" valign="center" halign="center">
       <convert type="ServiceName">Name</convert>
     </widget>
-    <eLabel backgroundColor="infobarBG" position="120,56" size="1040,14" zPosition="0"/>
-    <ePixmap pixmap="PLi-HD/dvr/scale1024.png" position="128,61" size="1024,4" zPosition="1" />
+    <!--eLabel backgroundColor="infobarBG" position="120,56" size="1040,14" zPosition="0"/-->
+    <ePixmap pixmap="PLi-HD/dvr/scale1024.png" position="128,61" size="1024,4" zPosition="1" alphatest="blend" />
     <widget source="session.CurrentService" render="PositionGauge" position="128,57" size="1024,12" transparent="1" zPosition="4" pointer="PLi-HD/dvr/position_pointer1024.png:1012,0">
       <convert type="ServicePosition">Gauge</convert>
     </widget>
-    <widget source="session.CurrentService" render="Label" position="128,31" size="90,25" backgroundColor="transparent" zPosition="4" foregroundColor="foreground" borderWidth="2" font="Regular;22" borderColor="black" valign="center" halign="left">
+    <widget source="session.CurrentService" render="Label" position="128,31" size="90,25" backgroundColor="black" transparent="1" zPosition="4" foregroundColor="foreground" borderWidth="2" font="Regular;22" borderColor="black" valign="center" halign="left">
       <convert type="ServicePosition">Position,ShowHours</convert>
     </widget>
-    <widget source="session.CurrentService" render="Label" position="1035,31" size="117,25" backgroundColor="transparent" zPosition="4" foregroundColor="foreground" borderWidth="2" font="Regular;22" borderColor="black" valign="center" halign="right">
+    <widget source="session.CurrentService" render="Label" position="1035,31" size="117,25" backgroundColor="black" transparent="1" zPosition="4" foregroundColor="foreground" borderWidth="2" font="Regular;22" borderColor="black" valign="center" halign="right">
       <convert type="ServicePosition">Remaining,Negate,ShowHours</convert>
     </widget>
     <widget source="session.RecordState" render="Pixmap" pixmap="PLi-HD/buttons/rec.png" position="1160,53" size="20,20" zPosition="3" alphatest="on">
       <convert type="ConditionalShowHide"></convert>
     </widget>
-    <widget source="global.CurrentTime" render="Label" borderWidth="2" position="1052,3" size="100,25" backgroundColor="transparent" noWrap="1" zPosition="1" foregroundColor="foreground" font="Regular;22" valign="center" halign="right">
+    <widget source="global.CurrentTime" render="Label" borderWidth="2" position="1052,3" size="100,25" backgroundColor="black" transparent="1" noWrap="1" zPosition="1" foregroundColor="foreground" font="Regular;22" valign="center" halign="right">
       <convert type="ClockToText">Format:%-H:%M</convert>
     </widget>
-    <widget source="session.CurrentService" render="Label" position="128,70" size="145,21" zPosition="2" backgroundColor="transparent" foregroundColor="foreground" font="Regular;20" borderWidth="2" valign="top" halign="left">
+    <widget source="session.CurrentService" render="Label" position="128,70" size="145,21" zPosition="2" backgroundColor="black" transparent="1" foregroundColor="foreground" font="Regular;20" borderWidth="2" valign="top" halign="left">
       <convert type="PliExtraInfo">ResolutionString</convert>
     </widget>
   </screen>
@@ -595,7 +597,7 @@
 
   <!-- Movie Player Infobar -->
 
-  <screen name="MoviePlayer" title="InfoBar" position="0,45" size="1280,91" backgroundColor="transparent" flags="wfNoBorder">
+  <screen name="MoviePlayer" title="InfoBar" position="0,540" size="1280,180" backgroundColor="transparent" flags="wfNoBorder">
     <panel name="PlayerTemplate"/>
     <widget source="session.CurrentService" render="Pixmap" pixmap="PLi-HD/infobar/ico_dolby_on.png" position="1078,70" size="33,21" zPosition="2" alphatest="on">
       <convert type="ServiceInfo">IsMultichannel</convert>
@@ -614,13 +616,13 @@
 
   <!-- DVD Player Infobar -->
 
-  <screen name="DVDPlayer" title="InfoBar" position="0,45" size="1280,215" backgroundColor="transparent" flags="wfNoBorder">
+  <screen name="DVDPlayer" title="InfoBar" position="0,540" size="1280,180" backgroundColor="transparent" flags="wfNoBorder">
     <panel name="PlayerTemplate"/>
-    <widget name="chapterLabel" position="280,80" size="380,35" font="Regular;20" halign="left" valign="center" noWrap="1" borderColor="black" borderWidth="2" backgroundColor="transparent" zPosition="3"></widget>
-    <eLabel text="Audio:  " position="280,115" size="90,35" backgroundColor="secondBG" transparent="1" font="Regular;20" borderColor="black" borderWidth="2" valign="center" halign="left"></eLabel>
-    <widget name="audioLabel" position="370,115" size="290,35" font="Regular;20" halign="left" valign="center" noWrap="1" borderColor="black" borderWidth="2" backgroundColor="transparent" zPosition="3"></widget>
-    <eLabel text="Subtitle:  " position="280,150" size="90,35" backgroundColor="secondBG" transparent="1" borderColor="black" borderWidth="2" font="Regular;20" valign="center" halign="left"></eLabel>
-    <widget name="subtitleLabel" position="370,150" size="290,35" font="Regular;20" halign="left" valign="center" noWrap="1" borderColor="black" borderWidth="2" backgroundColor="transparent" zPosition="3"></widget>
+    <widget name="chapterLabel" position="280,80" size="720,35" font="Regular;20" halign="left" valign="center" noWrap="1" borderColor="black" borderWidth="2" backgroundColor="black" transparent="1" zPosition="3"></widget>
+    <eLabel text="Audio:" position="280,115" size="90,35" backgroundColor="black" transparent="1" font="Regular;20" borderColor="black" borderWidth="2" valign="center" halign="right"></eLabel>
+    <widget name="audioLabel" position="375,115" size="290,35" font="Regular;20" halign="left" valign="center" noWrap="1" borderColor="black" borderWidth="2" backgroundColor="black" transparent="1" zPosition="3"></widget>
+    <eLabel text="Subtitle:" position="280,150" size="90,35" backgroundColor="black" transparent="1" borderColor="black" borderWidth="2" font="Regular;20" valign="center" halign="right"></eLabel>
+    <widget name="subtitleLabel" position="375,150" size="290,35" font="Regular;20" halign="left" valign="center" noWrap="1" borderColor="black" borderWidth="2" backgroundColor="black" transparent="1" zPosition="3"></widget>
     <widget name="anglePix" position="740,128" size="26,16" pixmap="skin_default/icons/icon_view.png" zPosition="3" alphatest="on"></widget>
     <widget name="angleLabel" position="780,122" size="200,22" font="Regular;21" backgroundColor="black" zPosition="3" transparent="1"></widget>
   </screen>
@@ -3102,7 +3104,7 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y()))
     </widget>
   </screen>
 
-  <screen name="MyTubePlayer" position="0,45" size="1280,100" backgroundColor="transparent" title="MoviePlayer" flags="wfNoBorder">
+  <screen name="MyTubePlayer" position="0,540" size="1280,180" backgroundColor="transparent" title="MoviePlayer" flags="wfNoBorder">
     <panel name="PlayerTemplate"/>
   </screen>
 


### PR DESCRIPTION
Here are some changes regarding the improved satfinder, as discussed here:
http://openpli.org/forums/topic/27724-improved-satfinder/page__st__20__gopid__334644

Besides the changes on the satfinder screen, were added red/green buttons to scan screen and hidden the "press ok to scan" message on these screen, since this message are useless and just clutter and confuses the new actions.

Screenshots attached.

![01_satfinder](https://f.cloud.github.com/assets/348516/160966/8440d5a4-777e-11e2-8aca-dc3e0adf9603.jpg)
![02_automatic_scan](https://f.cloud.github.com/assets/348516/160967/844249de-777e-11e2-89bc-472b7a63740f.jpg)
![03_manual_scan](https://f.cloud.github.com/assets/348516/160968/8447448e-777e-11e2-94a2-06c758321e71.jpg)
![04_fastscan](https://f.cloud.github.com/assets/348516/160969/8447c4b8-777e-11e2-87ea-dfdf57f67efb.jpg)
