### PR TITLE
Cosmetic in Movielist configuration

### DIFF
--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -1244,7 +1244,7 @@
   <screen name="MovieBrowserConfiguration" position="fill" flags="wfNoBorder">
     <panel name="PigTemplate"/>
     <panel name="ButtonTemplate_2"/>
-    <eLabel text="Movie List Configuration" position="85,30" size="1085,55" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="left" />
+    <eLabel text="Movie list configuration" position="85,30" size="1085,55" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="left" />
     <widget name="config" position="575,110" size="600,480" itemHeight="24" font="Regular;20" transparent="1" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" />
   </screen>
 


### PR DESCRIPTION
There in Movieselection.py and then in .po is used "Movie list configuration" and not "Movie List configuration", as it was used in skin.xml => was not translated. 
