### PR TITLE
Changes in ServiceScan screen: Better use of screen space

### DIFF
--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -535,7 +535,7 @@
 
   <!-- Service Scan -->
 
-  <screen name="ServiceScan" title="Service Scan" position="fill" flags="wfNoBorder">
+  <screen name="ServiceScan" title="Service scan" position="fill" flags="wfNoBorder">
     <panel name="BasicTemplate"/>
     <panel name="ButtonTemplate_RG"/>
     <widget source="FrontendInfo" render="Pixmap" pixmap="skin_default/icons/scan-s.png" position="80,120" size="64,64" zPosition="2" transparent="1" alphatest="on">


### PR DESCRIPTION
Changed ServiceScan screen layout in order make it use more screen space.
Added a title, passed FrontendInfo pixmap, network and transponder widgets from title panel to screen body.
Passed servicelist widget to right, to look more like other skin screens.

Minor changes in FastScanStatus, trying to fit the same ServiceScan layout.
(Couldn't make anything better, because FastScanStatus don't have servicelist widget)
![service_scan_20131026](https://f.cloud.github.com/assets/348516/1414758/bf388ddc-3ea7-11e3-81d8-ddb6864a31c0.jpg)
