### PR TITLE
enlarge PliExtraInfo label

### DIFF
--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -142,7 +142,7 @@
 
   <screen name="SecondInfoBar" title="Second InfoBar" position="fill" flags="wfNoBorder">
     <eLabel position="fill" backgroundColor="transpBlack" zPosition="0"/>
-    <widget source="session.CurrentService" render="Label" position="60,45" size="679,80" transparent="1" zPosition="1" foregroundColor="foreground" font="Regular;20" valign="top" halign="left">
+    <widget source="session.CurrentService" render="Label" position="60,45" size="900,90" transparent="1" zPosition="1" foregroundColor="foreground" font="Regular;20" valign="top" halign="left">
       <convert type="PliExtraInfo">All</convert>
     </widget>
     <eLabel name="snr" position="1022,47" size="50,16" borderWidth="1" borderColor="black" halign="left" transparent="1" zPosition="1" text="SNR" font="Regular;14" />


### PR DESCRIPTION
for some DVB-T was first line on second infobar longer than label and was moved to next line => 2nd and 3rd  lines were pushed down and 3rd line was cropped.
