### PR TITLE
Servicescan screen: add more space for scan_status messages

### DIFF
--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -638,9 +638,9 @@
     </widget>
     <widget name="network" position="135,105" size="675,45" valign="center" zPosition="2" font="Regular;33" transparent="1"/>
     <widget name="transponder" position="135,157" size="675,45" valign="center" zPosition="2" font="Regular;33" transparent="1"/>
-    <widget name="scan_state" position="30,270" zPosition="2" size="810,45" valign="center" font="Regular;30" transparent="1"/>
-    <widget name="pass" position="30,360" size="810,45" valign="center" font="Regular;33" transparent="1"/>
-    <widget name="scan_progress" position="30,322" size="810,22" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc"/>
+    <widget name="scan_state" position="30,300" zPosition="2" size="810,80" valign="top" font="Regular;30" transparent="1"/>
+    <widget name="pass" position="30,380" size="810,45" valign="center" font="Regular;33" transparent="1"/>
+    <widget name="scan_progress" position="30,270" size="810,22" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc"/>
     <widget name="servicelist" position="870,100" size="1020,912" itemHeight="38" font="Regular;28" selectionDisabled="1" scrollbarMode="showOnDemand"/>
   </screen>
 

--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -560,9 +560,9 @@
     </widget>
     <widget name="network" position="150,120" size="410,30" valign="center" zPosition="2" font="Regular;22" transparent="1" />
     <widget name="transponder" position="150,155" size="410,30" valign="center" zPosition="2" font="Regular;22" transparent="1" />
-    <widget name="scan_state" position="80,230" zPosition="2" size="510,30" valign="center" font="Regular;20" transparent="1" />
-    <widget name="pass" position="80,290" size="480,30" valign="center" font="Regular;22" transparent="1" />
-    <widget name="scan_progress" position="80,265" size="480,15" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc" />
+    <widget name="scan_state" position="80,250" zPosition="2" size="510,60" valign="top" font="Regular;20" transparent="1" />
+    <widget name="pass" position="80,310" size="480,30" valign="center" font="Regular;22" transparent="1" />
+    <widget name="scan_progress" position="80,230" size="480,15" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc" />
     <widget name="servicelist" position="610,110" size="640,500" selectionDisabled="1" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" />
   </screen>
 

--- a/usr/share/enigma2/PLi-HD1/skin.xml
+++ b/usr/share/enigma2/PLi-HD1/skin.xml
@@ -572,9 +572,9 @@
     </widget>
     <widget name="network" position="90,70" size="450,30" valign="center" zPosition="2" font="Regular;22" transparent="1"/>
     <widget name="transponder" position="90,105" size="450,30" valign="center" zPosition="2" font="Regular;22" transparent="1"/>
-    <widget name="scan_state" position="20,180" zPosition="2" size="540,30" valign="center" font="Regular;20" transparent="1"/>
-    <widget name="pass" position="20,240" size="540,30" valign="center" font="Regular;22" transparent="1"/>
-    <widget name="scan_progress" position="20,215" size="540,15" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc"/>
+    <widget name="scan_state" position="20,200" zPosition="2" size="540,60" valign="top" font="Regular;20" transparent="1"/>
+    <widget name="pass" position="20,260" size="540,30" valign="center" font="Regular;22" transparent="1"/>
+    <widget name="scan_progress" position="20,180" size="540,15" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc"/>
     <widget name="servicelist" position="580,70" size="680,600" selectionDisabled="1" scrollbarMode="showOnDemand"/>
   </screen>
 

--- a/usr/share/enigma2/PLi-HD2/skin.xml
+++ b/usr/share/enigma2/PLi-HD2/skin.xml
@@ -564,9 +564,9 @@
     </widget>
     <widget name="network" position="110,90" size="450,30" valign="center" zPosition="2" font="Regular;22" transparent="1" />
     <widget name="transponder" position="110,125" size="450,30" valign="center" zPosition="2" font="Regular;22" transparent="1" />
-    <widget name="scan_state" position="40,200" zPosition="2" size="550,30" valign="center" font="Regular;20" transparent="1" />
-    <widget name="pass" position="40,260" size="520,30" valign="center" font="Regular;22" transparent="1" />
-    <widget name="scan_progress" position="40,235" size="520,15" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc" />
+    <widget name="scan_state" position="40,220" zPosition="2" size="550,60" valign="top" font="Regular;20" transparent="1" />
+    <widget name="pass" position="40,280" size="520,30" valign="center" font="Regular;22" transparent="1" />
+    <widget name="scan_progress" position="40,200" size="520,15" pixmap="skin_default/progress_big.png" borderWidth="2" borderColor="#cccccc" />
     <widget name="servicelist" position="610,80" size="640,570" selectionDisabled="1" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" />
   </screen>
 


### PR DESCRIPTION
Make the scan_status widget a two liner - some languages use longer wordings for the scan messages then others, hence need more space to fit;
additionaly, a related cosmetic change - move scan progress bar up, and place the message under it, and also top-align the message - this way the second line of message won't be noticeable when empty.