### PR TITLE
[PLi FullHD] Tweaked remote channel stream converter & CI-menu

### DIFF
--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -2228,7 +2228,7 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
   <screen name="CiSelection" position="fill" title="Common Interface">
     <panel name="PigTemplate"/>
     <widget name="text" position="780,105" size="1100,35" font="Regular;32" />
-    <widget name="entries" position="780,160" size="1100,190" itemHeight="38" font="Regular;28" scrollbarMode="showOnDemand" />
+    <widget name="entries" position="780,160" size="1100,570" itemHeight="38" font="Regular;28" scrollbarMode="showOnDemand" />
   </screen>
 
   <!-- Subservices Quickzap -->

--- a/usr/share/enigma2/PLi-FullHD/skin_plugins.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin_plugins.xml
@@ -1546,7 +1546,7 @@
   <screen name="StreamingChannelFromServerScreen" position="fill" title="Select bouquets to convert" flags="wfNoBorder">
     <panel name="PigTemplate"/>
     <panel name="ButtonTemplate_RGYBS"/>
-    <widget name="list" position="780,105" size="1110,720" itemHeight="38" font="Regular;28" scrollbarMode="showOnDemand"/>
+    <widget name="list" position="780,105" size="1110,836" itemHeight="38" font="Regular;28" scrollbarMode="showOnDemand" enableWrapAround="1"/>
     <widget source="statusbar" render="Label" position="780,975" size="1110,34" zPosition="1" font="Regular;30" halign="center"/>
   </screen>
 


### PR DESCRIPTION
List in remote channel stream converter was too small and didn't have enableWrapAround.
CI-menu was too short; it showed only one slot and then even partial.