### PR TITLE
[PLi-FullNightHD] Two corrections.

### DIFF
--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -792,7 +792,7 @@
 		<widget source="session.Event_Now" render="Progress" pixmap="infobar/pbar.png" position="330,160" size="1260,12" transparent="1" zPosition="2" borderWidth="2" borderColor="secondBG">
 			<convert type="EventTime">Progress</convert>
 		</widget>
-		<widget source="RdsDecoder" render="Pixmap" pixmap="icons/rass_logo.png" position="90,90" size="150,90" zPosition="2" alphatest="on">
+		<widget source="RdsDecoder" render="Pixmap" pixmap="skin_default/icons/rass_logo.png" position="90,90" size="150,90" zPosition="2" alphatest="on">
 			<convert type="RdsInfo">RasInteractiveAvailable</convert>
 			<convert type="ConditionalShowHide"/>
 		</widget>

--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -763,14 +763,14 @@
 		<widget source="session.CurrentService" render="Label" position="330,105" size="1260,48" font="Regular;39" foregroundColor="grey" halign="center">
 			<convert type="ServiceName">Name</convert>
 		</widget>
-		<widget source="session.Event_Now" render="Label" position="10,180" size="105,45" font="Regular;36" foregroundColor="foregroundColor" halign="left">
+		<widget source="session.Event_Now" render="Label" position="10,180" size="105,45" font="Regular;36" foregroundColor="foreground" halign="left">
 			<convert type="EventTime">StartTime</convert>
 			<convert type="ClockToText">Default</convert>
 		</widget>
-		<widget source="session.Event_Now" render="Label" position="127,180" size="1570,45" font="Regular;36" foregroundColor="foregroundColor" noWrap="1" halign="left">
+		<widget source="session.Event_Now" render="Label" position="127,180" size="1570,45" font="Regular;36" foregroundColor="foreground" noWrap="1" halign="left">
 			<convert type="EventName">Name</convert>
 		</widget>
-		<widget source="session.Event_Now" render="Label" position="1720,180" size="180,45" font="Regular;34"  foregroundColor="foregroundColor" halign="right">
+		<widget source="session.Event_Now" render="Label" position="1720,180" size="180,45" font="Regular;34"  foregroundColor="foreground" halign="right">
 			<convert type="EventTime">Remaining</convert>
 			<convert type="RemainingToText">InMinutes</convert>
 		</widget>

--- a/usr/share/enigma2/PLi-FullNightHD/skin_plugins.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin_plugins.xml
@@ -1975,8 +1975,8 @@
 		<widget name="label3" position="678,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
 		<panel name="ButtonYellow"/>
 		<widget name="label2" position="1114,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
-		<panel name="MenuBPanel"/>
-		<panel name="InfoBPanel"/>
+		<panel name="KeyMenuTemplate"/>
+		<panel name="KeyInfoTemplate"/>
 		<panel name="KeyOkTemplate"/>
 		<widget name="textpage" position="785,120" size="1127,855" font="Regular;33" foregroundColor="grey"/>
 		<widget name="pic1" position="0,550" size="200,150" alphatest="blend" zPosition="1"/>
@@ -1994,8 +1994,8 @@
 		<widget name="label3" position="678,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
 		<panel name="ButtonYellow"/>
 		<widget name="label2" position="1114,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
-		<panel name="MenuBPanel"/>
-		<panel name="InfoBPanel"/>
+		<panel name="KeyMenuTemplate"/>
+		<panel name="KeyInfoTemplate"/>
 		<panel name="KeyOkTemplate"/>
 		<widget name="textpage" position="785,120" size="1127,855" font="Regular;33" foregroundColor="grey"/>
 		<widget name="pic1" position="0,550" size="200,150" alphatest="blend" zPosition="1"/>
@@ -2013,8 +2013,8 @@
 		<widget name="label3" position="678,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
 		<panel name="ButtonYellow"/>
 		<widget name="label2" position="1114,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
-		<panel name="MenuBPanel"/>
-		<panel name="InfoBPanel"/>
+		<panel name="KeyMenuTemplate"/>
+		<panel name="KeyInfoTemplate"/>
 		<panel name="KeyOkTemplate"/>
 		<widget name="textpage" position="785,120" size="1127,855" font="Regular;33" foregroundColor="grey"/>
 		<widget name="pic1" position="0,550" size="200,150" alphatest="blend" zPosition="1"/>


### PR DESCRIPTION
1- Typo in RadioInfoBar
2- Wrong button templates in WikiPedia.
3- Corrected rass-logo issue (see http://forums.openpli.org/topic/44407-cpp-crash-in-radio-mode/)