### PR TITLE
Remove obsolete "CancelOKTemplate" from "TimerEntry" screen

### DIFF
--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -1025,7 +1025,6 @@
   <screen name="TimerEntry" position="fill" title="Timer entry" flags="wfNoBorder">
     <panel name="PigTemplate"/>
     <!--panel name="KeyMenuInfoTemplate"/-->
-    <panel name="CancelOKTemplate"/>
     <widget name="config" position="780,105" size="1110,765" itemHeight="38" font="Regular;28" scrollbarMode="showOnDemand"/>
   </screen>
 

--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -1044,7 +1044,6 @@
 
 	<screen name="TimerEntry" position="fill" title="Timer entry" flags="wfNoBorder">
 		<panel name="PigTemplate"/>
-		<panel name="CancelOKTemplate"/>
 		<widget name="config" position="780,105" size="1110,765" itemHeight="38" font="Regular;28" scrollbarMode="showOnDemand"/>
 	</screen>
 

--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -927,7 +927,6 @@
   <screen name="TimerEntry" position="fill" title="Timer entry" flags="wfNoBorder">
     <panel name="PigTemplate"/>
     <!--panel name="KeyMenuInfoTemplate"/-->
-    <panel name="CancelOKTemplate"/>
     <widget name="config" position="530,110" size="690,500" itemHeight="28" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" />
   </screen>
 

--- a/usr/share/enigma2/PLi-HD1/skin.xml
+++ b/usr/share/enigma2/PLi-HD1/skin.xml
@@ -996,7 +996,6 @@
   <screen name="TimerEntry" position="fill" title="Timer entry" flags="wfNoBorder">
     <panel name="PigTemplate"/>
     <!--panel name="KeyMenuInfoTemplate"/-->
-    <panel name="CancelOKTemplate"/>
     <widget name="config" position="520,70" size="740,510" itemHeight="28" scrollbarMode="showOnDemand"/>
   </screen>
 

--- a/usr/share/enigma2/PLi-HD2/skin.xml
+++ b/usr/share/enigma2/PLi-HD2/skin.xml
@@ -939,7 +939,6 @@
   <screen name="TimerEntry" position="fill" title="Timer entry" flags="wfNoBorder">
     <panel name="PigTemplate"/>
     <!--panel name="KeyMenuInfoTemplate"/-->
-    <panel name="CancelOKTemplate"/>
     <widget name="config" position="530,80" size="710,500" itemHeight="28" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" />
   </screen>
 


### PR DESCRIPTION
This follows the proposed change here: https://github.com/OpenPLi/enigma2/pull/1236

I din't remove the "CancelOKTemplate" altogether from the skin_templates.xml because it's still been used in the some of the plugins.