### PR TITLE
Remove osbolete "initializetext" widget from "HarddiskSetup" screen

### DIFF
--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -1581,7 +1581,6 @@
     <widget name="model" position="780,105" size="1110,37" font="Regular;36"/>
     <widget name="capacity" position="780,210" size="1110,37" font="Regular;36"/>
     <widget name="bus" position="780,255" size="1110,37" font="Regular;36"/>
-    <widget name="initializetext" position="242,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
   </screen>
 
   <!-- Help -->

--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -1707,7 +1707,6 @@
 		<widget name="model" position="780,105" size="1110,37" font="Regular;36"/>
 		<widget name="capacity" position="780,210" size="1110,37" font="Regular;36"/>
 		<widget name="bus" position="780,255" size="1110,37" font="Regular;36"/>
-		<widget name="initializetext" position="242,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
 	</screen>
 
 	<!-- Help -->

--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -1476,7 +1476,6 @@
     <widget name="model" position="530,110" size="380,25" font="Regular;24" />
     <widget name="capacity" position="530,140" size="380,25" font="Regular;24" />
     <widget name="bus" position="530,170" size="380,25" font="Regular;24" />
-    <widget name="initializetext" position="185,643" size="220,28" backgroundColor="black" zPosition="1" transparent="1" font="Regular;24" halign="left" />
   </screen>
 
   <!-- Help -->

--- a/usr/share/enigma2/PLi-HD1/skin.xml
+++ b/usr/share/enigma2/PLi-HD1/skin.xml
@@ -1545,7 +1545,6 @@
     <widget name="model" position="520,70" size="740,25" font="Regular;24"/>
     <widget name="capacity" position="520,140" size="740,25" font="Regular;24"/>
     <widget name="bus" position="520,170" size="740,25" font="Regular;24"/>
-    <widget name="initializetext" position="165,687" size="230,28" backgroundColor="black" zPosition="1" transparent="1" font="Regular;24" halign="left"/>
   </screen>
 
   <!-- Help -->

--- a/usr/share/enigma2/PLi-HD2/skin.xml
+++ b/usr/share/enigma2/PLi-HD2/skin.xml
@@ -1488,7 +1488,6 @@
     <widget name="model" position="530,80" size="380,25" font="Regular;24" />
     <widget name="capacity" position="530,140" size="380,25" font="Regular;24" />
     <widget name="bus" position="530,170" size="380,25" font="Regular;24" />
-    <widget name="initializetext" position="185,682" size="220,28" backgroundColor="black" zPosition="1" transparent="1" font="Regular;24" halign="left" />
   </screen>
 
   <!-- Help -->


### PR DESCRIPTION
After the recent changes in "HarddiskSetup" screen, the "initializetext" widget is not needed anymore. 

See: https://github.com/OpenPLi/enigma2/commit/a584c537e1130c33d9dfd0d0545a126a8d148e7c