### PR TITLE
Template: add a hook for menu and info buttons

### DIFF
--- a/usr/share/enigma2/PLi-FullNightHD/skin_templates.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin_templates.xml
@@ -127,6 +127,21 @@
 		<panel name="ButtonBlue"/>
 		<widget objectTypes="key_blue,Label,Button" name="key_blue" position="1550,1030" size="370,38" backgroundColor="black" zPosition="1" transparent="1" font="Regular;34" halign="left"/>
 		<widget objectTypes="key_blue,StaticText" source="key_blue" render="Label" position="1550,1030" size="370,38" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;34" halign="left"/>
+
+		<panel name="KeyMenuAutoTemplate"/>
+		<panel name="KeyInfoAutoTemplate"/>
+	</screen>
+
+	<screen name="KeyMenuAutoTemplate"><!-- show with Components.Sources.Boolean -->
+		<widget source="key_menu" conditional="key_menu" render="Pixmap" pixmap="skin_default/buttons/key_menu.png" alphatest="blend" position="82,1031" size="52,38">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+	</screen>
+
+	<screen name="KeyInfoAutoTemplate"><!-- show with Components.Sources.Boolean -->
+		<widget source="key_info" conditional="key_info" render="Pixmap" pixmap="skin_default/buttons/key_info.png" alphatest="blend" position="135,1031" size="52,38">
+			<convert type="ConditionalShowHide"/>
+		</widget>
 	</screen>
 
 	<screen name="KeyMenuTemplate">


### PR DESCRIPTION
This allows info and menu buttons to be controlled from the Python code without editing the skin.
Variable  names are: key_menu and key_info to conform with key names used in "keyids.py".

Example use

from Components.Sources.Boolean import Boolean
self["key_info"] = Boolean()
if showinfokey:
	self["key_info"].boolean = True
else:
	self["key_info"].boolean = False)