### PR TITLE
Enable PiG on the console screen

### DIFF
--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -728,8 +728,8 @@
 	<!-- Console -->
 
 	<screen name="Console" title="Command execution" position="fill" flags="wfNoBorder">
-		<panel name="BasicTemplate"/>
-		<widget name="text" position="30,100" size="1860,912" itemHeight="38" font="Fixed;28" transparent="1" foregroundColor="white" scrollbarMode="showOnDemand"/>
+		<panel name="PigTemplate"/>
+		<widget name="text" position="825,100" size="990,912" itemHeight="38" font="Fixed;28" transparent="1" foregroundColor="white" scrollbarMode="showOnDemand"/>
 	</screen>
 
 	<!-- NumberZap -->


### PR DESCRIPTION
When running a user script from Hotkey display the PiG windows so we can still watch TV while script is running.