### PR TITLE
virtual keyboard - remove unused 'country'

### DIFF
--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -2004,7 +2004,6 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 
   <screen name="VirtualKeyBoard" position="fill" zPosition="99" flags="wfNoBorder">
     <panel name="PigTemplate"/>
-    <widget source="country" render="Label" position="1114,1030" size="370,38" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;34" halign="left"/>
     <ePixmap pixmap="PLi-FullHD/skin_default/vkey_text.png" position="927,235" size="816,78" zPosition="-4" alphatest="on"/>
     <widget name="header" position="930,120" size="810,39" transparent="1" noWrap="1" font="Regular;33" valign="top"/>
     <widget name="text" position="930,255" size="804,51" transparent="1" noWrap="1" font="Regular;38" valign="center" halign="right"/>

--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -2127,7 +2127,6 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 
 	<screen name="VirtualKeyBoard" position="fill" zPosition="99" flags="wfNoBorder">
 		<panel name="PigTemplate"/>
-		<widget source="country" render="Label" position="1114,1030" size="370,38" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;34" halign="left"/>
 		<ePixmap pixmap="PLi-FullNightHD/skin_default/vkey_text.png" position="927,235" size="816,78" zPosition="-4" alphatest="on"/>
 		<widget name="header" position="930,120" size="810,39" transparent="1" noWrap="1" font="Regular;33" valign="top"/>
 		<widget name="text" position="930,255" size="804,51" transparent="1" noWrap="1" font="Regular;38" valign="center" halign="right"/>

--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -1909,7 +1909,6 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 
   <screen name="VirtualKeyBoard" position="fill" zPosition="99" flags="wfNoBorder">
     <panel name="PigTemplate"/>
-    <widget source="country" render="Label" position="735,643" size="220,28" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;24" halign="left" />
     <ePixmap pixmap="skin_default/vkey_text.png" position="588,145" size="542,52" zPosition="-4" alphatest="on" />
     <widget name="header" position="590,110" size="500,26" transparent="1" noWrap="1" font="Regular;20" valign="top"/>
     <widget name="text" position="590,150" size="536,34" transparent="1" noWrap="1" font="Regular;26" valign="center" halign="right" />

--- a/usr/share/enigma2/PLi-HD1/skin.xml
+++ b/usr/share/enigma2/PLi-HD1/skin.xml
@@ -1967,7 +1967,6 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 
   <screen name="VirtualKeyBoard" position="fill" zPosition="99" flags="wfNoBorder">
     <panel name="PigTemplate"/>
-    <widget source="country" render="Label" position="745,687" size="230,28" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;24" halign="left"/>
     <ePixmap pixmap="skin_default/vkey_text.png" position="618,140" size="542,52" zPosition="-4" alphatest="on"/>
     <widget name="header" position="620,80" size="540,26" transparent="1" noWrap="1" font="Regular;22" valign="top"/>
     <widget name="text" position="620,150" size="536,34" transparent="1" noWrap="1" font="Regular;26" valign="center" halign="right"/>

--- a/usr/share/enigma2/PLi-HD2/skin.xml
+++ b/usr/share/enigma2/PLi-HD2/skin.xml
@@ -1924,7 +1924,6 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 
   <screen name="VirtualKeyBoard" position="fill" zPosition="99" flags="wfNoBorder">
     <panel name="PigTemplate"/>
-    <widget source="country" render="Label" position="735,682" size="220,28" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;24" halign="left" />
     <ePixmap pixmap="skin_default/vkey_text.png" position="588,145" size="542,52" zPosition="-4" alphatest="on" />
     <widget name="header" position="590,80" size="500,26" transparent="1" noWrap="1" font="Regular;20" valign="top"/>
     <widget name="text" position="590,150" size="536,34" transparent="1" noWrap="1" font="Regular;26" valign="center" halign="right" />


### PR DESCRIPTION
Country flag is possible display as:
`<widget source="country" render="Pixmap" position="930,800" size="60,40" alphatest="on" borderWidth="2" borderColor="black">
      <convert type="ValueToPixmap">LanguageCode</convert>
    </widget>`