### PR TITLE
split epg_description into epg_eventname and FullDescription

### DIFF
--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -421,7 +421,8 @@
 	<screen name="EventView" title="Eventview" position="fill" flags="wfNoBorder">
 		<panel name="SelectionTemplate"/>
 		<panel name="KeyMenuTemplate"/>
-		<widget name="epg_description" position="780,100" size="1110,912" transparent="1" font="Regular;30" halign="block"/>
+		<widget name="epg_eventname" position="780,100" size="1110,912" transparent="1" font="Regular;30" halign="left"/>
+		<widget name="FullDescription" position="780,160" size="1110,912" transparent="1" font="Regular;30" halign="block"/>
 		<widget source="Service" render="Label" position="30,525" size="720,30" foregroundColor="transponderinfo" font="Regular;26" valign="center" halign="left" transparent="1" zPosition="1">
 			<convert type="TransponderInfo"></convert>
 		</widget>

--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -421,7 +421,7 @@
 	<screen name="EventView" title="Eventview" position="fill" flags="wfNoBorder">
 		<panel name="SelectionTemplate"/>
 		<panel name="KeyMenuTemplate"/>
-		<widget name="epg_eventname" position="780,100" size="1110,912" transparent="1" font="Regular;30" halign="left"/>
+		<widget name="epg_eventname" position="780,100" size="1110,40" transparent="1" font="Regular;30" halign="left"/>
 		<widget name="FullDescription" position="780,160" size="1110,912" transparent="1" font="Regular;30" halign="block"/>
 		<widget source="Service" render="Label" position="30,525" size="720,30" foregroundColor="transponderinfo" font="Regular;26" valign="center" halign="left" transparent="1" zPosition="1">
 			<convert type="TransponderInfo"></convert>

--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -395,7 +395,7 @@
 	<screen name="EventView" title="Eventview" position="fill" flags="wfNoBorder">
 		<panel name="SelectionTemplate"/>
 		<panel name="KeyMenuTemplate"/>
-		<widget name="epg_eventname" position="780,100" size="1110,912" transparent="1" font="Regular;30" halign="left"/>
+		<widget name="epg_eventname" position="780,100" size="1110,40" transparent="1" font="Regular;30" halign="left"/>
 		<widget name="FullDescription" position="780,160" size="1110,912" transparent="1" font="Regular;30" halign="block"/>
 		<widget source="Service" render="Label" position="30,525" size="720,30" foregroundColor="foreground" font="Regular;26" valign="center" halign="center" transparent="1" zPosition="1">
 			<convert type="TransponderInfo"/>

--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -395,7 +395,8 @@
 	<screen name="EventView" title="Eventview" position="fill" flags="wfNoBorder">
 		<panel name="SelectionTemplate"/>
 		<panel name="KeyMenuTemplate"/>
-		<widget name="epg_description" position="780,100" size="1110,912" transparent="1" font="Regular;30" halign="block"/>
+		<widget name="epg_eventname" position="780,100" size="1110,912" transparent="1" font="Regular;30" halign="left"/>
+		<widget name="FullDescription" position="780,160" size="1110,912" transparent="1" font="Regular;30" halign="block"/>
 		<widget source="Service" render="Label" position="30,525" size="720,30" foregroundColor="foreground" font="Regular;26" valign="center" halign="center" transparent="1" zPosition="1">
 			<convert type="TransponderInfo"/>
 		</widget>

--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -386,7 +386,8 @@
     <widget source="Event" render="Label" position="360,440" size="120,26" font="Regular;18" backgroundColor="secondBG" zPosition="1" transparent="1" foregroundColor="foreground" halign="left">
       <convert type="EventName">PdcTime</convert>
     </widget-->
-    <widget name="epg_description" position="540,110" size="680,500" transparent="1" font="Regular;22" />
+    <widget name="epg_eventname" position="540,110" size="680,500" transparent="1" font="Regular;22" halign="left" />
+    <widget name="FullDescription" position="540,154" size="680,500" transparent="1" font="Regular;22" />
     <widget source="session.Event_Now" render="Label" position="150,475" size="150,30" transparent="1" zPosition="1" foregroundColor="foreground" font="Regular;22" halign="right">
       <convert type="EventTime">Remaining</convert>
       <convert type="RemainingToText">InMinutes</convert>

--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -386,7 +386,7 @@
     <widget source="Event" render="Label" position="360,440" size="120,26" font="Regular;18" backgroundColor="secondBG" zPosition="1" transparent="1" foregroundColor="foreground" halign="left">
       <convert type="EventName">PdcTime</convert>
     </widget-->
-    <widget name="epg_eventname" position="540,110" size="680,500" transparent="1" font="Regular;22" halign="left" />
+    <widget name="epg_eventname" position="540,110" size="680,30" transparent="1" font="Regular;22" halign="left" />
     <widget name="FullDescription" position="540,154" size="680,500" transparent="1" font="Regular;22" />
     <widget source="session.Event_Now" render="Label" position="150,475" size="150,30" transparent="1" zPosition="1" foregroundColor="foreground" font="Regular;22" halign="right">
       <convert type="EventTime">Remaining</convert>

--- a/usr/share/enigma2/PLi-HD1/skin.xml
+++ b/usr/share/enigma2/PLi-HD1/skin.xml
@@ -403,7 +403,7 @@
   <screen name="EventView" title="Eventview" position="fill" flags="wfNoBorder">
     <panel name="SelectionTemplate"/>
     <panel name="KeyMenuTemplate"/>
-    <widget name="epg_eventname" position="520,70" size="740,600" transparent="1" font="Regular;22" halign="left"/>
+    <widget name="epg_eventname" position="520,70" size="740,30" transparent="1" font="Regular;22" halign="left"/>
     <widget name="FullDescription" position="520,114" size="740,600" transparent="1" font="Regular;22" halign="block"/>
     <widget source="Service" render="Label" position="20,350" size="482,20" foregroundColor="transponderinfo" font="Regular;16" valign="center" halign="left" transparent="1" zPosition="1">
       <convert type="TransponderInfo">NoRoot</convert>

--- a/usr/share/enigma2/PLi-HD1/skin.xml
+++ b/usr/share/enigma2/PLi-HD1/skin.xml
@@ -403,7 +403,8 @@
   <screen name="EventView" title="Eventview" position="fill" flags="wfNoBorder">
     <panel name="SelectionTemplate"/>
     <panel name="KeyMenuTemplate"/>
-    <widget name="epg_description" position="520,70" size="740,600" transparent="1" font="Regular;22" halign="block"/>
+    <widget name="epg_eventname" position="520,70" size="740,600" transparent="1" font="Regular;22" halign="left"/>
+    <widget name="FullDescription" position="520,114" size="740,600" transparent="1" font="Regular;22" halign="block"/>
     <widget source="Service" render="Label" position="20,350" size="482,20" foregroundColor="transponderinfo" font="Regular;16" valign="center" halign="left" transparent="1" zPosition="1">
       <convert type="TransponderInfo">NoRoot</convert>
     </widget>

--- a/usr/share/enigma2/PLi-HD2/skin.xml
+++ b/usr/share/enigma2/PLi-HD2/skin.xml
@@ -382,7 +382,8 @@
     <widget name="channel"  position="40,395" size="450,30" transparent="1" font="Regular;22" halign="left" />
     <widget name="datetime" position="40,435" size="450,30" transparent="1" font="Regular;22" halign="left" />
     <widget name="duration" position="40,475" size="450,30" transparent="1" font="Regular;22" halign="left" />
-    <widget name="epg_description" position="530,80" size="710,575" transparent="1" font="Regular;22" halign="block"/>
+    <widget name="epg_eventname" position="530,80" size="710,575" transparent="1" font="Regular;22" halign="left" />
+    <widget name="FullDescription" position="530,122" size="710,575" transparent="1" font="Regular;22" halign="block" />
     <widget source="session.Event_Now" render="Label" position="110,475" size="190,30" transparent="1" zPosition="1" foregroundColor="foreground" font="Regular;22" halign="right">
       <convert type="EventTime">Remaining</convert>
       <convert type="RemainingToText">InMinutes</convert>

--- a/usr/share/enigma2/PLi-HD2/skin.xml
+++ b/usr/share/enigma2/PLi-HD2/skin.xml
@@ -382,7 +382,7 @@
     <widget name="channel"  position="40,395" size="450,30" transparent="1" font="Regular;22" halign="left" />
     <widget name="datetime" position="40,435" size="450,30" transparent="1" font="Regular;22" halign="left" />
     <widget name="duration" position="40,475" size="450,30" transparent="1" font="Regular;22" halign="left" />
-    <widget name="epg_eventname" position="530,80" size="710,575" transparent="1" font="Regular;22" halign="left" />
+    <widget name="epg_eventname" position="530,80" size="710,30" transparent="1" font="Regular;22" halign="left" />
     <widget name="FullDescription" position="530,122" size="710,575" transparent="1" font="Regular;22" halign="block" />
     <widget source="session.Event_Now" render="Label" position="110,475" size="190,30" transparent="1" zPosition="1" foregroundColor="foreground" font="Regular;22" halign="right">
       <convert type="EventTime">Remaining</convert>


### PR DESCRIPTION
Use new epg_eventname variable.
Align epg_eventname to the <left> to prevent event names with spaces between the words,
like 'The    big   bang    theory" or 'game     of     thrones' with some services e.g. BBC One.
Fulldescription can still be alinged in <block>.

Also this gives skin builders the possibility to change color, position, size, aligment and font
of event name without changing full description.

This requires enigma2 changes.