### PR TITLE
[PLi-FullNightHD] Fix SecondInfoBar background

### DIFF
--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -81,7 +81,7 @@
 		<color name="selectedBG" value="#06303240"/>
 		<color name="selectedFG" value="#00fcc000"/>
 		<color name="transparent" value="#ff000000"/>
-		<color name="transpBlack" value="#54111112"/>
+		<color name="transpBlack" value="#2d101214"/>
 		<color name="transpDark" value="#54242424"/>
 		<color name="transpWhite" value="#70f0f0f0"/>
 		<color name="un33333a" value="#0033333a"/>


### PR DESCRIPTION
SecondInfoBar background is the wrong shade. It does not match FirstInfoBar background. It is too light and the low contrast causes readability problems.

With this change, the first and second InfoBars are identical in shade.